### PR TITLE
Include constructor position, lifecycle sequence reference. 

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-lifecycle-methods.md
+++ b/packages/eslint-plugin/docs/rules/sort-lifecycle-methods.md
@@ -243,6 +243,45 @@ class Test {
 }
 ```
 
+<br>
+
+---
+
+<br>
+
+#### Default Config
+
+```json
+{
+  "rules": {
+    "@angular-eslint/sort-lifecycle-methods": [
+      "error"
+    ]
+  }
+}
+```
+
+<br>
+
+#### ❌ Invalid Code
+
+```ts
+@Component()
+class Test {
+  ngOnChanges(): void {}
+  ngOnInit(): void {}
+  ngDoCheck(): void {}
+  ngAfterContentInit(): void {}
+  ngAfterContentChecked(): void {}
+  ngAfterViewInit(): void {}
+  ngAfterViewChecked(): void {}
+  ngOnDestroy(): void {}
+  ~~~~~~~~~~~
+  constructor() {}
+  doSomethingElse(): void {}
+}
+```
+
 </details>
 
 <br>
@@ -288,6 +327,17 @@ class Test {
 
 @Component()
 class Test {
+  ngOnChanges(): void {}
+  ngOnInit(): void {}
+  ngAfterContentInit(): void {}
+  ngAfterContentChecked(): void {}
+  ngAfterViewChecked(): void {}
+  ngOnDestroy(): void {}
+}
+
+@Component()
+class Test {
+  constructor() {}
   ngOnChanges(): void {}
   ngOnInit(): void {}
   ngAfterContentInit(): void {}

--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -29,12 +29,12 @@
     "@angular-eslint/prefer-output-readonly": "error",
     "@angular-eslint/prefer-standalone-component": "error",
     "@angular-eslint/relative-url-prefix": "error",
+    "@angular-eslint/sort-lifecycle-methods": "error",
     "@angular-eslint/sort-ngmodule-metadata-arrays": "error",
     "@angular-eslint/use-component-selector": "error",
     "@angular-eslint/use-component-view-encapsulation": "error",
     "@angular-eslint/use-injectable-provided-in": "error",
     "@angular-eslint/use-lifecycle-interface": "error",
-    "@angular-eslint/use-pipe-transform-interface": "error",
-    "@angular-eslint/sort-lifecycle-methods": "error"
+    "@angular-eslint/use-pipe-transform-interface": "error"
   }
 }

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -138,12 +138,12 @@ export = {
     [preferStandaloneComponentRuleName]: preferStandaloneComponent,
     [preferOutputReadonlyRuleName]: preferOutputReadonly,
     [relativeUrlPrefixRuleName]: relativeUrlPrefix,
+    [sortLifecycleMethodsRuleName]: sortLifecycleMethods,
     [sortNgmoduleMetadataArraysName]: sortNgmoduleMetadataArrays,
     [useComponentSelectorRuleName]: useComponentSelector,
     [useComponentViewEncapsulationRuleName]: useComponentViewEncapsulation,
     [useInjectableProvidedInRuleName]: useInjectableProvidedIn,
     [useLifecycleInterfaceRuleName]: useLifecycleInterface,
     [usePipeTransformInterfaceRuleName]: usePipeTransformInterface,
-    [sortLifecycleMethodsRuleName]: sortLifecycleMethods,
   },
 };

--- a/packages/eslint-plugin/tests/rules/sort-lifecycle-methods/cases.ts
+++ b/packages/eslint-plugin/tests/rules/sort-lifecycle-methods/cases.ts
@@ -1,14 +1,12 @@
-// import {convertAnnotatedSourceToFailureCase} from '@angular-eslint/utils';
-// import type {MessageIds} from '../../../src/rules/sort-lifecycle-methods';
-
-// const messageId: MessageIds = 'sortLifecycleMethods';
 import { convertAnnotatedSourceToFailureCase } from '@angular-eslint/utils';
 import type { MessageIds } from '../../../src/rules/sort-lifecycle-methods';
 
+const lifecycleMethodBeforeConstructor: MessageIds =
+  'lifecycleMethodBeforeConstructor';
 const lifecycleMethodsNotSorted: MessageIds = 'lifecycleMethodsNotSorted';
-
 const nonLifecycleMethodBeforeLifecycleMethod: MessageIds =
   'nonLifecycleMethodBeforeLifecycleMethod';
+
 export const valid = [
   `
     @Component()
@@ -23,7 +21,8 @@ export const valid = [
       ngOnDestroy(): void {}
       doSomething(): void {}
     }
-
+  `,
+  `
     @Component()
     class Test {
       ngOnChanges(): void {}
@@ -33,7 +32,20 @@ export const valid = [
       ngAfterViewChecked(): void {}
       ngOnDestroy(): void {}
     }
-
+  `,
+  `
+    @Component()
+    class Test {
+      constructor() {}
+      ngOnChanges(): void {}
+      ngOnInit(): void {}
+      ngAfterContentInit(): void {}
+      ngAfterContentChecked(): void {}
+      ngAfterViewChecked(): void {}
+      ngOnDestroy(): void {}
+    }
+  `,
+  `
     @Component()
     class Test {
       ngDoCheck(): void {}
@@ -44,16 +56,17 @@ export const valid = [
       doSomethingElse(): void {}
       doSomethingElseAgain(): void {}
     }
-
+  `,
+  `
     @Component()
     class Test {
       ngOnInit(): void {}
     }
-
+  `,
+  `
     @Component()
-    class Test {
-    }
-    `,
+    class Test {}
+  `,
 ];
 
 export const invalid = [
@@ -153,5 +166,25 @@ export const invalid = [
       }
       `,
     messageId: nonLifecycleMethodBeforeLifecycleMethod,
+  }),
+  convertAnnotatedSourceToFailureCase({
+    description: 'lifecycle hook is declared before constructor()',
+    annotatedSource: `
+      @Component()
+      class Test {
+        ngOnChanges(): void {}
+        ngOnInit(): void {}
+        ngDoCheck(): void {}
+        ngAfterContentInit(): void {}
+        ngAfterContentChecked(): void {}
+        ngAfterViewInit(): void {}
+        ngAfterViewChecked(): void {}
+        ngOnDestroy(): void {}
+        ~~~~~~~~~~~
+        constructor() {}
+        doSomethingElse(): void {}
+      }
+      `,
+    messageId: lifecycleMethodBeforeConstructor,
   }),
 ];

--- a/packages/utils/src/eslint-plugin/ast-utils.ts
+++ b/packages/utils/src/eslint-plugin/ast-utils.ts
@@ -593,6 +593,10 @@ export function isArrayExpression(
   return node.type === AST_NODE_TYPES.ArrayExpression;
 }
 
+export function isConstructor(method: TSESTree.MethodDefinition): boolean {
+  return getMethodName(method) === 'constructor';
+}
+
 export function isProperty(node: TSESTree.Node): node is TSESTree.Property {
   return node.type === AST_NODE_TYPES.Property;
 }

--- a/packages/utils/src/eslint-plugin/ast-utils.ts
+++ b/packages/utils/src/eslint-plugin/ast-utils.ts
@@ -91,6 +91,10 @@ export const angularLifecycleInterfaceKeys = objectKeys(
 );
 export const angularLifecycleMethodKeys = objectKeys(AngularLifecycleMethods);
 
+/**
+ * See lifecycle event sequence:
+ * https://angular.io/guide/lifecycle-hooks#lifecycle-event-sequence
+ */
 export const angularLifecycleMethodsOrdered = [
   AngularLifecycleMethods.ngOnChanges,
   AngularLifecycleMethods.ngOnInit,
@@ -101,6 +105,7 @@ export const angularLifecycleMethodsOrdered = [
   AngularLifecycleMethods.ngAfterViewChecked,
   AngularLifecycleMethods.ngOnDestroy,
 ];
+
 export const ANGULAR_CLASS_DECORATOR_LIFECYCLE_METHOD_MAPPER: ReadonlyMap<
   AngularClassDecoratorKeys,
   ReadonlySet<AngularLifecycleMethodKeys>


### PR DESCRIPTION
@Friendseeker Updated to include constructor position - should be before lifecycle methods - and address feedback from initial PR. Note: I believe we wanted these to be in order or execution and not chronological. Please let me know what you think.